### PR TITLE
Read config parameters from file

### DIFF
--- a/PhotosExporter.xcodeproj/project.pbxproj
+++ b/PhotosExporter.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A33E6EB25A0F76F00A1A5BF /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A33E6E925A0F76F00A1A5BF /* Config.swift */; };
+		2A33E6EC25A0F76F00A1A5BF /* MediaGroupFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A33E6EA25A0F76F00A1A5BF /* MediaGroupFilter.swift */; };
 		E1321E502229A71600046C00 /* StopWatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1321E4F2229A71600046C00 /* StopWatch.swift */; };
 		E186D26022354098000BFCED /* FlatFolderDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E186D25F22354098000BFCED /* FlatFolderDescriptor.swift */; };
 		E1A55240222AB2EF00F72499 /* String+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5523F222AB2EF00F72499 /* String+extensions.swift */; };
@@ -24,6 +26,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2A33E6E925A0F76F00A1A5BF /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
+		2A33E6EA25A0F76F00A1A5BF /* MediaGroupFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaGroupFilter.swift; sourceTree = "<group>"; };
 		E1321E4F2229A71600046C00 /* StopWatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopWatch.swift; sourceTree = "<group>"; };
 		E186D25F22354098000BFCED /* FlatFolderDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlatFolderDescriptor.swift; sourceTree = "<group>"; };
 		E1A5523F222AB2EF00F72499 /* String+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extensions.swift"; sourceTree = "<group>"; };
@@ -90,6 +94,8 @@
 		E1E43B16217CDB62000E76DF /* exporter */ = {
 			isa = PBXGroup;
 			children = (
+				2A33E6E925A0F76F00A1A5BF /* Config.swift */,
+				2A33E6EA25A0F76F00A1A5BF /* MediaGroupFilter.swift */,
 				E1E43B17217CDB6A000E76DF /* PhotosExporter.swift */,
 				E1E43B18217CDB6E000E76DF /* SnapshotPhotosExporter.swift */,
 				E1E43B09217CDB53000E76DF /* IncrementalPhotosExporter.swift */,
@@ -201,6 +207,8 @@
 				E1E43B1D217CDBE9000E76DF /* SnapshotPhotosExporter.swift in Sources */,
 				E1B119262251DC8100B53693 /* Errors.swift in Sources */,
 				E1A55240222AB2EF00F72499 /* String+extensions.swift in Sources */,
+				2A33E6EC25A0F76F00A1A5BF /* MediaGroupFilter.swift in Sources */,
+				2A33E6EB25A0F76F00A1A5BF /* Config.swift in Sources */,
 				E1E43AF6217CDABA000E76DF /* AppDelegate.swift in Sources */,
 				E1E43B13217CDB54000E76DF /* MediaLibUtil.swift in Sources */,
 				E186D26022354098000BFCED /* FlatFolderDescriptor.swift in Sources */,
@@ -341,7 +349,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bentele.PhotosExporter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -358,7 +366,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.bentele.PhotosExporter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/PhotosExporter/exporter/Config.swift
+++ b/PhotosExporter/exporter/Config.swift
@@ -1,0 +1,264 @@
+//
+//  Config.swift
+//  PhotosExporter
+//
+//  Created by Kai Unger on 30.12.20.
+//  Copyright © 2020 Andreas Bentele. All rights reserved.
+//
+
+import Foundation
+import MediaLibrary
+
+// Hierarchical organization of Apple's Photo's as seen in Photos 3.0 (3291.13.210) on macOS 10.13.6 (17G66)
+//    type=com.apple.Photos.RootGroup, name=Optional("Fotos")
+//        type=com.apple.Photos.AllMomentsGroup, name=Optional("Momente")
+//            type=com.apple.Photos.MomentGroup, name=Optional("...")
+//            ... more moments ...
+//        type=com.apple.Photos.AllCollectionsGroup, name=Optional("Sammlungen")
+//            type=com.apple.Photos.CollectionGroup, name=Optional("...")
+//            ... more collections ...
+//        type=com.apple.Photos.AllYearsGroup, name=Optional("Jahre")
+//            type=com.apple.Photos.YearGroup, name=Optional("...")
+//            ... more years ...
+//        type=com.apple.Photos.PlacesAlbum, name=Optional("Orte")
+//            type=com.apple.Photos.PlacesCountryAlbum, name=Optional("Dänemark")
+//                type=com.apple.Photos.PlacesProvinceAlbum, name=Optional("Nordjylland")
+//                    type=com.apple.Photos.PlacesCityAlbum, name=Optional("Hirtshals")
+//                        type=com.apple.Photos.PlacesPointOfInterestAlbum, name=Optional("Vendsyssel-Thy")
+//        type=com.apple.Photos.SharedGroup, name=Optional("Freigegeben")
+//            type=com.apple.Photos.SharedPhotoStream, name=Optional("...")
+//            ... more shared albums ...
+//        type=com.apple.Photos.AlbumsGroup, name=Optional("Alben")
+//            type=com.apple.Photos.FacesAlbum, name=Optional("Personen")
+//                type=com.apple.Photos.FacesAlbum, name=Optional("...")
+//                ... more individual persons ...
+//            type=com.apple.Photos.VideosGroup, name=Optional("Videos")
+//            type=com.apple.Photos.FrontCameraGroup, name=Optional("Selfies")
+//            type=com.apple.Photos.PanoramasGroup, name=Optional("Panoramen")
+//            type=com.apple.Photos.ScreenshotGroup, name=Optional("Bildschirmfotos")
+//            type=com.apple.Photos.MyPhotoStream, name=Optional("Mein Fotostream")
+//            type=com.apple.Photos.Album, name=Optional("... album name ...")
+//            type=com.apple.Photos.Folder, name=Optional("... some folder name ...")
+//                type=com.apple.Photos.SmartAlbum, name=Optional("... some album name ...")
+//                type=com.apple.Photos.Album, name=Optional("... another album name ...")
+
+// Folders and albums and smart albums can be nested individually.
+
+// Media objects appear on any level aggregating from the most specific towards the root media group.
+// E.g. a photo contained in com.apple.Photos.PlacesPointOfInterestAlbum appears
+// a second time in com.apple.Photos.PlacesCityAlbum,
+// a third time in com.apple.Photos.PlacesProvinceAlbum
+// a fourth time in com.apple.Photos.PlacesCountryAlbum
+// a fifth time in com.apple.Photos.PlacesAlbum
+// a sixth time in com.apple.Photos.RootGroup
+
+func debugPhotosGroupTypeIdConstants() {
+    let logger = Logger(loggerName: "PhotosExporter", logLevel: .debug)
+    
+    logger.debug("MLPhotosAlbumTypeIdentifier: \(MLPhotosAlbumTypeIdentifier)")
+    logger.debug("MLPhotosAlbumsGroupTypeIdentifier \(MLPhotosAlbumsGroupTypeIdentifier)")
+    logger.debug("MLPhotosAllCollectionsGroupTypeIdentifier \(MLPhotosAllCollectionsGroupTypeIdentifier)")
+    logger.debug("MLPhotosAllMomentsGroupTypeIdentifier \(MLPhotosAllMomentsGroupTypeIdentifier)")
+    logger.debug("MLPhotosAllPhotosAlbumTypeIdentifier \(MLPhotosAllPhotosAlbumTypeIdentifier)")
+    logger.debug("MLPhotosAllYearsGroupTypeIdentifier \(MLPhotosAllYearsGroupTypeIdentifier)")
+    logger.debug("MLPhotosBurstGroupTypeIdentifier \(MLPhotosBurstGroupTypeIdentifier)")
+    logger.debug("MLPhotosCollectionGroupTypeIdentifier \(MLPhotosCollectionGroupTypeIdentifier)")
+    logger.debug("MLPhotosDepthEffectGroupTypeIdentifier \(MLPhotosDepthEffectGroupTypeIdentifier)")
+    logger.debug("MLPhotosFacesAlbumTypeIdentifier \(MLPhotosFacesAlbumTypeIdentifier)")
+    logger.debug("MLPhotosFavoritesGroupTypeIdentifier \(MLPhotosFavoritesGroupTypeIdentifier)")
+    logger.debug("MLPhotosFolderTypeIdentifier \(MLPhotosFolderTypeIdentifier)")
+    logger.debug("MLPhotosFrontCameraGroupTypeIdentifier \(MLPhotosFrontCameraGroupTypeIdentifier)")
+    logger.debug("MLPhotosLastImportGroupTypeIdentifier \(MLPhotosLastImportGroupTypeIdentifier)")
+    logger.debug("MLPhotosMomentGroupTypeIdentifier \(MLPhotosMomentGroupTypeIdentifier)")
+    logger.debug("MLPhotosMyPhotoStreamTypeIdentifier \(MLPhotosMyPhotoStreamTypeIdentifier)")
+    logger.debug("MLPhotosPanoramasGroupTypeIdentifier \(MLPhotosPanoramasGroupTypeIdentifier)")
+    logger.debug("MLPhotosPublishedAlbumTypeIdentifier \(MLPhotosPublishedAlbumTypeIdentifier)")
+    logger.debug("MLPhotosRootGroupTypeIdentifier \(MLPhotosRootGroupTypeIdentifier)")
+    logger.debug("MLPhotosScreenshotGroupTypeIdentifier \(MLPhotosScreenshotGroupTypeIdentifier)")
+    logger.debug("MLPhotosSharedGroupTypeIdentifier \(MLPhotosSharedGroupTypeIdentifier)")
+    logger.debug("MLPhotosSharedPhotoStreamTypeIdentifier \(MLPhotosSharedPhotoStreamTypeIdentifier)")
+    logger.debug("MLPhotosSloMoGroupTypeIdentifier \(MLPhotosSloMoGroupTypeIdentifier)")
+    logger.debug("MLPhotosSmartAlbumTypeIdentifier \(MLPhotosSmartAlbumTypeIdentifier)")
+    logger.debug("MLPhotosTimelapseGroupTypeIdentifier \(MLPhotosTimelapseGroupTypeIdentifier)")
+    logger.debug("MLPhotosVideosGroupTypeIdentifier \(MLPhotosVideosGroupTypeIdentifier)")
+    logger.debug("MLPhotosYearGroupTypeIdentifier \(MLPhotosYearGroupTypeIdentifier)")
+}
+
+enum PhotoGroups : String, Codable {
+    case Moments
+    case Collections
+    case Years
+    case Places
+
+    case Faces
+    case Videos
+    case Selfies
+    case Panoramas
+    case Screenshots
+    
+    case Albums
+    case SmartAlbums
+}
+
+struct ExporterConfig : Codable {
+    enum ExporterType : String, Codable {
+        case incremental
+        case snapshot
+    }
+    
+    // define which media groups should be exported
+    public var groupsToExport: [PhotoGroups]
+    // Level of logging. Only messages with this level or higher will be logged
+    public var logLevel: LogLevel
+    public var exporterType: ExporterType
+    // Location (file system folder) where to put the exported files
+    public var targetPath: String
+    // (only IncrementalPhotosExporter, optional parameter): the path to an already existing export folder on the same device; example: export all photos using SnapshotPhotosExporter to your local disk or SSD; create a backup using Time Machine; additionally export the photos using IncrementalPhotosExporter to the same device as your Time Machine backup. Then you would set the baseExportPath to the export folder within your Time Machine backup, to link the exported photos with the photos of your Time Machine backup to save disk space.
+    public var baseExportPath: String?
+    // Switches whether the original photos (masters) shall be exported
+    public var exportOriginals: Bool
+    // Switches whether the edited photos (rendered as jpegs) shall be exported
+    public var exportCalculated: Bool
+    // Switches whether the "flat" folder wich contains all photos
+    // shall be deleted after the export is finished
+    //
+    // This parameter is ignored by the incremental exporter
+    //
+    // Note: If this is true and groupsToExport is empty,
+    // effectively nothing will be exported, because the flat folder
+    // is the only folder created during export
+    public var deleteFlatPathAfterExport: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case exporterType
+        case targetPath
+        case baseExportPath
+        case groupsToExport
+        case logLevel
+        case exportOriginals
+        case exportCalculated
+        case deleteFlatPathAfterExport
+    }
+}
+
+func createDefaultExporterConfig(exporterType: ExporterConfig.ExporterType,
+                                 targetPath: String) -> ExporterConfig
+{
+    return ExporterConfig(
+        groupsToExport:
+        [PhotoGroups.Moments,
+         PhotoGroups.Collections,
+         PhotoGroups.Years,
+         PhotoGroups.Places,
+         
+         PhotoGroups.Faces,
+         PhotoGroups.Videos,
+         PhotoGroups.Selfies,
+         PhotoGroups.Panoramas,
+         PhotoGroups.Screenshots,
+         
+         PhotoGroups.Albums,
+         PhotoGroups.SmartAlbums],
+        logLevel: LogLevel.info,
+        exporterType: exporterType,
+        targetPath: targetPath,
+        baseExportPath: nil,
+        exportOriginals: true,
+        exportCalculated: true,
+        deleteFlatPathAfterExport: true)
+}
+
+class MainConfig : Codable {
+    public var exporterConfigs : [ExporterConfig]
+        = [createDefaultExporterConfig(exporterType: ExporterConfig.ExporterType.snapshot,
+                                       targetPath: "/Users/andreas/Pictures/Fotos Library export"),
+           createDefaultExporterConfig(exporterType: ExporterConfig.ExporterType.incremental,
+                                       targetPath: "/Volumes/WD-4TB/Fotos Library export")]
+}
+
+func nameOfApp() -> String {
+    let bundle = Bundle.main
+    if let appNameAny = bundle.object(forInfoDictionaryKey: "CFBundleDisplayName")
+        ?? bundle.object(forInfoDictionaryKey: kCFBundleNameKey as String)
+        , let appNameString = appNameAny as? String
+    {
+        return appNameString
+    }
+    
+    return "PhotosExporter"
+}
+
+struct ConfigStorage {
+    public var logger : Logger
+    
+    func configFolderURL() -> URL {
+        let applicationSupportFolderURL = try! FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let appName = nameOfApp()
+        let myFolderInApplicationSupportFolderURL = applicationSupportFolderURL.appendingPathComponent("\(appName)",
+            isDirectory: true)
+        
+        return myFolderInApplicationSupportFolderURL
+    }
+    
+    func configFileURL() -> URL {
+        let configFolder = configFolderURL()
+        return configFolder.appendingPathComponent("config.json", isDirectory: false)
+    }
+    
+    func defaultConfigFileURL() -> URL {
+        let configFolder = configFolderURL()
+        return configFolder.appendingPathComponent("default_config.json", isDirectory: false)
+    }
+    
+    func ensureApplicationSupportFolderExists() throws {
+        let myFolderInApplicationSupportFolderURL = configFolderURL()
+        
+        do {
+            try FileManager.default.createDirectory(atPath: myFolderInApplicationSupportFolderURL.path,
+                                                    withIntermediateDirectories: true,
+                                                    attributes: nil)
+        } catch {
+            logger.error("Unable to create directory \(myFolderInApplicationSupportFolderURL): \(error)")
+            throw error
+        }
+    }
+    
+    func writeConfig(url: URL, data: Data) {
+        do {
+            try ensureApplicationSupportFolderExists()
+            try data.write(to: url)
+        } catch let error as NSError {
+            // Handle error
+            logger.error("Failed to write config data to \(url): \(error)")
+        }
+    }
+    
+    func createDefaultConfig() throws {
+        let config = MainConfig()
+        let fileToWrite = defaultConfigFileURL()
+        
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        
+        let data = try encoder.encode(config)
+        try data.write(to: fileToWrite)
+    }
+    
+    func tryToReadConfig() -> MainConfig? {
+        var config: MainConfig? = nil
+        do {
+            let configFile = configFileURL()
+            let jsonData = try Data(contentsOf: configFile)
+            let jsonDecoder = JSONDecoder()
+            do {
+                config = try jsonDecoder.decode(MainConfig.self, from: jsonData)
+            } catch {
+                logger.error("Failed to parse config from \(configFileURL): \(error)")
+            }
+        } catch {
+            logger.error("Failed to read config file \(configFileURL): \(error)")
+        }
+        
+        return config
+    }
+}

--- a/PhotosExporter/exporter/IncrementalPhotosExporter.swift
+++ b/PhotosExporter/exporter/IncrementalPhotosExporter.swift
@@ -12,6 +12,10 @@ import Foundation
  * backup mode, like "Time Machine", which creates one folder per date and which is a real copy of the Photos Library data.
  */
 class IncrementalPhotosExporter : PhotosExporter {
+    override init(exporterConfig: ExporterConfig) {
+        super.init(exporterConfig: exporterConfig)
+        self.baseExportPath = exporterConfig.baseExportPath
+    }
     
     private var latestPath: String {
         return "\(targetPath)/Latest"

--- a/PhotosExporter/exporter/MediaGroupFilter.swift
+++ b/PhotosExporter/exporter/MediaGroupFilter.swift
@@ -1,0 +1,55 @@
+//
+//  MediaGroupFilter.swift
+//  PhotosExporter
+//
+//  Created by Kai Unger on 01.01.21.
+//  Copyright © 2021 Andreas Bentele. All rights reserved.
+//
+
+import Foundation
+import MediaLibrary
+
+struct MediaGroupFilter
+{
+    func matches(_ group: MLMediaGroup) -> Bool {
+        switch group.typeIdentifier {
+        case MLPhotosMomentGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Moments)
+        case MLPhotosCollectionGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Collections)
+        case MLPhotosYearGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Years)
+        case "com.apple.Photos.PlacesCountryAlbum":
+            return self.photoGroups.contains(PhotoGroups.Places)
+        case "com.apple.Photos.PlacesProvinceAlbum":
+            return self.photoGroups.contains(PhotoGroups.Places)
+        case "com.apple.Photos.PlacesCityAlbum":
+            return self.photoGroups.contains(PhotoGroups.Places)
+        case "com.apple.Photos.PlacesPointOfInterestAlbum":
+            return self.photoGroups.contains(PhotoGroups.Places)
+        case MLPhotosFacesAlbumTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Faces)
+                // Photos' "Faces" album has typeIdentifier MLPhotosFacesAlbumTypeIdentifier
+                // and all the faces albums of individual persons have the same identifier, too.
+                // The individual faces albums are children of the "Faces" album.
+                // We are only interested in the individual faces albums, thus we
+                // match only the faces albums which are children of the top level "Faces" album:
+                && (group.parent?.typeIdentifier == MLPhotosFacesAlbumTypeIdentifier)
+        case MLPhotosVideosGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Videos)
+        case MLPhotosFrontCameraGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Selfies)
+        case MLPhotosPanoramasGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Panoramas)
+        case MLPhotosScreenshotGroupTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Screenshots)
+        case MLPhotosAlbumTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.Albums)
+        case MLPhotosSmartAlbumTypeIdentifier:
+            return self.photoGroups.contains(PhotoGroups.SmartAlbums)
+        default:
+            return false
+        }
+    }
+    var photoGroups: [PhotoGroups]
+}

--- a/PhotosExporter/exporter/SnapshotPhotosExporter.swift
+++ b/PhotosExporter/exporter/SnapshotPhotosExporter.swift
@@ -12,12 +12,16 @@ import Foundation
  * simple export mode which creates one snapshot folder, with hard links to the original files to save disk space (only if the target directory is in the same file system as the Photos Library)
  */
 class SnapshotPhotosExporter : PhotosExporter {
+    override init(exporterConfig: ExporterConfig) {
+        super.init(exporterConfig: exporterConfig)
+        deleteFlatPathAfterExport = exporterConfig.deleteFlatPathAfterExport
+    }
     
     private var subTargetPath: String {
         return "\(targetPath)/Current"
     }
     
-    public var deleteFlatPath = true
+    public var deleteFlatPathAfterExport = true
     
     override func exportFoldersFlat() throws {
         if exportOriginals {
@@ -79,7 +83,7 @@ class SnapshotPhotosExporter : PhotosExporter {
         try super.finishExport()
         
         // remove the ".flat" folders
-        if (deleteFlatPath) {
+        if (deleteFlatPathAfterExport) {
             try deleteFolderIfExists(atPath: "\(inProgressPath)/\(originalsRelativePath)/\(flatRelativePath)")
             try deleteFolderIfExists(atPath: "\(inProgressPath)/\(calculatedRelativePath)/\(flatRelativePath)")
         }

--- a/PhotosExporter/util/Logger.swift
+++ b/PhotosExporter/util/Logger.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum LogLevel: String {
+enum LogLevel: String, Codable {
     case debug
     case info
     case warn

--- a/Readme.md
+++ b/Readme.md
@@ -38,10 +38,16 @@ This program was not my first try. I've tried out some other solutions before, t
 The final step was to re-implement everything using Apple's latest programming language [Swift](https://developer.apple.com/swift/) and the [MediaLibrary Framework](https://developer.apple.com/documentation/medialibrary). The result is a very robust, performant and maintainable solution compared to the previous solutions.
 
 
+# Compilation
+You have checkout the project, open it in Xcode and compile it. You are free to customize the code to your needs, but it's not required.
+
 # Usage
 
 Currently the program doesn't have any arguments and no user interface.
-You have checkout the project, open it in Xcode, open `MainExporter.swift` and modify the parameters, most important `targetPath`. Be sure the target path is on a file system which supports hard links. You are free to customize the code to your needs, but it's not required.
+
+It will try to read a json config file from your Application Support directory. In case the config is not available the programm will create a default config file for you and print out information about where to save a customized config file from it.
+
+Be sure the target path is on a file system which supports hard links. 
 
 Then run the program with Xcode, or compile the project and use the executable to export your photos.
 
@@ -49,22 +55,32 @@ Normally, the exporter adds the timestamp of a photo to the exported photo's fil
 
 If you move the exported folder, be sure to recreate the `Latest` link, because it would be broken after moving the folders.
 
-## Parameters of the exporter
+## Parameters in config file
 
-All parameters can be applied both to the SnapshotPhotosExporter and to IncrementalPhotosExporter.
+The configuration file contains a list of exporters to be run. Each exporter has these parameters: 
 
-* exportMediaGroupFilter: filter for the media groups (default: all media groups are exported)
-* exportPhotosOfMediaGroupFilter: filter for photos in a media group (default: all media groups are exported)
-* exportMediaObjectFilter: filter for media objects (default: all media objects are exported)
-* exportCalculated: set to false if calculated photos should not be exported (default: true)
-* exportOriginals: set to false if calculated photos should not be exported (default: true)
-* baseExportPath (only IncrementalPhotosExporter, optional parameter): the path to an already existing export folder on the same device; example: export all photos using SnapshotPhotosExporter to your local disk or SSD; create a backup using Time Machine; additionally export the photos using IncrementalPhotosExporter to the same device as your Time Machine backup. Then you would set the baseExportPath to the export folder within your Time Machine backup, to link the exported photos with the photos of your Time Machine backup to save disk space.
-* deleteFlatPath (only SnapshotPhotosExporter, optional parameter): true if the .flat folders should be deleted after the export (default:true; disable deleting if you want to use the export folder as base for an incremental export, see parameter baseExportPath)
+* `exportCalculatedPhotos`: set to false if calculated photos (edited) should not be exported (default: true)
+* `exportOriginalPhotos`: set to false if original photos (masters) should not be exported (default: true)
+* `deleteFlatPathAfterExport` (ignored by incremental exporter): true if the `.flat` folders should be deleted after the export (default:true; disable deleting if you want to use the export folder as base for an incremental export, see parameter baseExportPath)
+* `targetPath`: Directory where to put the exported folders and photos (needs to be on a volume supporting hard links)
+* `baseExportPath` (only IncrementalPhotosExporter, optional parameter): the path to an already existing export folder on the same device; example: export all photos using SnapshotPhotosExporter to your local disk or SSD; create a backup using Time Machine; additionally export the photos using IncrementalPhotosExporter to the same device as your Time Machine backup. Then you would set the baseExportPath to the export folder within your Time Machine backup, to link the exported photos with the photos of your Time Machine backup to save disk space.
+* `logLevel`: Verbosity of output. Valid levels are: debug, info, warn, error
+* `groupsToExport`: Selection of groups for which folders shall be created in the export folder. Exported photos are hard linked into these folders. Available groups are "Moments", "Collections", "Years", "Places", "Faces", "Videos", "Selfies", "Panoramas", "Screenshots", "Albums", "SmartAlbums". 
+  * Note: If "Places" is selected, subfolders for country, province, city and poi will be created.
+  * Note: If `groupsToExport` is empty only the `.flat` folder is created during export
+* `exporterType`: `snapshot` or `incremental`
+
+## Parameters hard coded
+
+In addition to the parameters read from the config file these parameters are currently hard coded:
+
+* `exportMediaGroupFilter`: filter for the media groups (default: all media groups are exported)
+* `exportMediaObjectFilter`: filter for media objects (default: all media objects are exported)
 
 # Supported platforms
 
 * macOS 10.14 "Mojave" (tested by the maintainer)
-* macOS 10.13 "High Sierra" (should work, but untested, unsupported)
+* macOS 10.13 "High Sierra", Photos 3.0, XCode 10.1, Swift 4.2 (tested by Kai Unger)
 
 # Implementation
 


### PR DESCRIPTION
The configuration parameters where hard coded at several places in different files.
Although the export process and its parameters were well documented in Readme.md it was not
that easy to find all the places in code that needed adaption. Furthermore configuration changes
needed a recompilation of the app.

Most configuration parameters have been concentrated into a new struct in Config.swift by this commit.

Additionally the process will try to read the config from a json file in the user's Application Support folder.
If such file does not exist the process will create a default config file and print some information how to
setup the user's config file.

The logic of the export process itself is not changed by this commit.