### PR TITLE
Avoid IndexOutOfRange error

### DIFF
--- a/PhotosExporter/photolibrary-access/PhotosMetadataReader.swift
+++ b/PhotosExporter/photolibrary-access/PhotosMetadataReader.swift
@@ -242,6 +242,9 @@ class PhotosMetadataReader {
     // workaround to get the derived URL (didn't find any API for this)
     func getDerivedUrl(photosLibraryPath: String, mediaObject: MediaObject) -> URL? {
         let originalPathComponents = mediaObject.originalUrl!.pathComponents
+        if originalPathComponents == nil {
+            return nil
+        }
         let subFolder = originalPathComponents[originalPathComponents.count - 2]
         
         let derivedPath = "\(photosLibraryPath)/resources/derivatives/\(subFolder)/\(mediaObject.zuuid())_1_100_o.jpeg"


### PR DESCRIPTION
Under some situation, line 244 originalPathComponents becomes nil so that letting subFolder line will fail.
Adding nil check for originalPathComponents on after 244 line.