### PR TITLE
fix: macOS 14.6.1 sqlite keyword schema

### DIFF
--- a/PhotosExporter/photolibrary-access/PhotosSqliteDAO.swift
+++ b/PhotosExporter/photolibrary-access/PhotosSqliteDAO.swift
@@ -86,7 +86,7 @@ class PhotosSqliteDAO {
             """
             SELECT ZASSET.zuuid, zkeyword.ZTITLE
             FROM Z_1KEYWORDS
-            join zkeyword on zkeyword.Z_PK = z_1keywords.z_40keywords
+            join zkeyword on zkeyword.Z_PK = z_1keywords.z_41keywords
             join ZADDITIONALASSETATTRIBUTES on ZADDITIONALASSETATTRIBUTES.z_pk = Z_1ASSETATTRIBUTES
             join ZASSET on ZASSET.ZADDITIONALATTRIBUTES = ZADDITIONALASSETATTRIBUTES.Z_PK
             """


### PR DESCRIPTION
changed from jz_1keywords.z_40keywords to jz_1keywords.z_40keywords