### PR TITLE
fix: macOS 14.6.1 - get SystemLibraryPath

### DIFF
--- a/PhotosExporter/photolibrary-access/PhotoLibraryUtil.swift
+++ b/PhotosExporter/photolibrary-access/PhotoLibraryUtil.swift
@@ -41,7 +41,11 @@ class PhotoLibraryUtil {
             let fileUrl = URL(fileURLWithPath: "Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist", relativeTo: libraryDirectoryUrl)
             print("fileUrl: \(fileUrl)")
             if let dictionary = NSDictionary(contentsOfFile: fileUrl.path) {
-                return dictionary["SystemLibraryPath"] as? String
+                guard let libs = dictionary["PLLibraryBookmarkManagerBookmarksByPath"] as? [String:Data] else {
+                    return nil
+                }
+                let result = libs.keys.first
+                return result
             }
         }
         

--- a/PhotosExporter/photolibrary-access/PhotoLibraryUtil.swift
+++ b/PhotosExporter/photolibrary-access/PhotoLibraryUtil.swift
@@ -38,14 +38,10 @@ class PhotoLibraryUtil {
         if libraryDirectoryUrls.count > 0 {
             let libraryDirectoryUrl = libraryDirectoryUrls[0]
             print("containerUrl: \(libraryDirectoryUrl)")
-            let fileUrl = URL(fileURLWithPath: "Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist", relativeTo: libraryDirectoryUrl)
+            let fileUrl = URL(fileURLWithPath: "Containers/com.apple.photolibraryd/Data/Library/Preferences/group.com.apple.photolibraryd.private.plist", relativeTo: libraryDirectoryUrl)
             print("fileUrl: \(fileUrl)")
             if let dictionary = NSDictionary(contentsOfFile: fileUrl.path) {
-                guard let libs = dictionary["PLLibraryBookmarkManagerBookmarksByPath"] as? [String:Data] else {
-                    return nil
-                }
-                let result = libs.keys.first
-                return result
+                return dictionary["SystemLibraryPath"] as? String
             }
         }
         


### PR DESCRIPTION
Instead of reading the missing `SystemLibraryPath` we can assume (no docs found) that the `PLLibraryBookmarkManagerBookmarksByPath` contains the libraries path...
Getting the first is obviously too weak!
Suggestions?